### PR TITLE
Add Mac OS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
 CPPFLAGS ?= $(INC_FLAGS) -MMD -MP
+CFLAGS := -std=c99
 
 $(TARGET): $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) -o $@ $(LOADLIBES) $(LDLIBS)
@@ -19,7 +20,7 @@ clean:
 
 -include $(DEPS)
 
-# On the Linux command line:
+# On the Linux or Mac OS command line:
 # make		creates tiff and leaves a bunch of object files in /src
 # make clean	deletes the object files as well as tiff
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ relying on C libraries for middleware and other wheels that you don't want to re
 It's set up to compile to flash memory. Code space is flash (big) so that data space can be small.
 
 Try `bin/tiff.exe` to play, if you like to live dangerously.
-If you're a Linux user, compile from source using the Makefile.
+If you're a Linux or Mac OS user, compile from source using the Makefile.
 On Windows, I just pull all files in `src` into a Code::Blocks console project.
 
 Windows users would do well to run this console app under Conemu.

--- a/examples/ANS/vmConsole.c
+++ b/examples/ANS/vmConsole.c
@@ -12,7 +12,7 @@
     vmKeyFormat = 0 for Windows, 1 for Linux. The escape sequences are different.
 */
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 #include <string.h>
 #include <unistd.h>
 #include <sys/select.h>
@@ -22,7 +22,7 @@
 #include <conio.h>
 #endif // __linux__
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 // Linux uses cooked mode to input a command line (see Tiff.c's QUIT loop).
 // Any keyboard input uses raw mode.
 // Apparently, Windows getch does this switchover for us.
@@ -100,7 +100,7 @@ uint32_t vmKeyFormat(uint32_t dummy) {
 
 uint32_t vmEmit(uint32_t c) {
     putchar(c);
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
     fflush(stdout);
     usleep(1000);
 #endif

--- a/examples/ANS/vmConsole.h
+++ b/examples/ANS/vmConsole.h
@@ -4,7 +4,7 @@
 #ifndef __VMCONSOLE_H__
 #define __VMCONSOLE_H__
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 void CookedMode();
 void RawMode();
 #endif // __linux__

--- a/examples/helloworld/vmConsole.c
+++ b/examples/helloworld/vmConsole.c
@@ -12,7 +12,7 @@
     vmKeyFormat = 0 for Windows, 1 for Linux. The escape sequences are different.
 */
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 #include <string.h>
 #include <unistd.h>
 #include <sys/select.h>
@@ -22,7 +22,7 @@
 #include <conio.h>
 #endif // __linux__
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 // Linux uses cooked mode to input a command line (see Tiff.c's QUIT loop).
 // Any keyboard input uses raw mode.
 // Apparently, Windows getch does this switchover for us.
@@ -100,7 +100,7 @@ uint32_t vmKeyFormat(uint32_t dummy) {
 
 uint32_t vmEmit(uint32_t c) {
     putchar(c);
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
     fflush(stdout);
     usleep(1000);
 #endif

--- a/examples/helloworld/vmConsole.h
+++ b/examples/helloworld/vmConsole.h
@@ -4,7 +4,7 @@
 #ifndef __VMCONSOLE_H__
 #define __VMCONSOLE_H__
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 void CookedMode();
 void RawMode();
 #endif // __linux__

--- a/src/accessvm.c
+++ b/src/accessvm.c
@@ -15,7 +15,7 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/ioctl.h>
 #include <unistd.h>
 

--- a/src/readme.md
+++ b/src/readme.md
@@ -16,7 +16,7 @@ This brings also Forth-like scripting and interactivity to C applications.
 
 ## Host Forth
 
-The Host Forth is implemented in generic C. I use Code::Blocks to compile for Windows and execute it in ConEmu for decent VT220 emulation. I also compile and test it under Ubuntu Linux. Tiff is the name of the console application.
+The Host Forth is implemented in generic C. I use Code::Blocks to compile for Windows and execute it in ConEmu for decent VT220 emulation. I also compile and test it under Ubuntu Linux. It is also supposed to work with Mac OS. Tiff is the name of the console application.
 
 It implements an interpreter and a number of words using C. They use data structures in the Forth VM whenever possible. This tends to be more wordy than simply using C data structures, but it allows C functions to be replaced by Forth versions as they become available. For example, when the C version of the interpreter fills the TIB with text using C's `getline`, the Forth system running in the VM sees that same text in its TIB.
 

--- a/src/vmConsole.c
+++ b/src/vmConsole.c
@@ -12,7 +12,7 @@
     vmKeyFormat = 0 for Windows, 1 for Linux. The escape sequences are different.
 */
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <string.h>
 #include <unistd.h>
 #include <sys/select.h>
@@ -22,7 +22,7 @@
 #include <conio.h>
 #endif // __linux__
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 // Linux uses cooked mode to input a command line (see Tiff.c's QUIT loop).
 // Any keyboard input uses raw mode.
 // Apparently, Windows getch does this switchover for us.
@@ -100,7 +100,7 @@ uint32_t vmKeyFormat(uint32_t dummy) {
 
 uint32_t vmEmit(uint32_t c) {
     putchar(c);
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
     fflush(stdout);
     usleep(1000);
 #endif

--- a/src/vmConsole.h
+++ b/src/vmConsole.h
@@ -4,7 +4,7 @@
 #ifndef __VMCONSOLE_H__
 #define __VMCONSOLE_H__
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 void CookedMode();
 void RawMode();
 #endif // __linux__


### PR DESCRIPTION
Hello Bradly, thanks for the nice work on Tiffany. 

I tried and added Mac OS support and made the appropriate changes. Tiffany compiles on an old Mac OS X 10.6 (Snow Leopard) and also on an newer  Mac OS 10.12 (Sierra). Please consider adapting my changes.

Regards, Ulli